### PR TITLE
replace ':' with ';' for comments in unit files as per systemd documentation

### DIFF
--- a/pkg/systemd/parser/unitfile.go
+++ b/pkg/systemd/parser/unitfile.go
@@ -204,7 +204,7 @@ func (f *UnitFile) Dup() *UnitFile {
 }
 
 func lineIsComment(line string) bool {
-	return len(line) == 0 || line[0] == '#' || line[0] == ':'
+	return len(line) == 0 || line[0] == '#' || line[0] == ':' || line[0] == ';'
 }
 
 func lineIsGroup(line string) bool {

--- a/pkg/systemd/parser/unitfile_test.go
+++ b/pkg/systemd/parser/unitfile_test.go
@@ -314,6 +314,35 @@ func TestUnitDropinPaths_Search(t *testing.T) {
 	}
 }
 
+func TestCommentsIgnored(t *testing.T) {
+	unitWithComments := `
+[Container]
+# comment
+Name=my-container
+: second comment
+; another comment
+`
+	f := NewUnitFile()
+	if e := f.Parse(unitWithComments); e != nil {
+		panic(e)
+	}
+
+	groups := f.ListGroups()
+	assert.Len(t, groups, 1)
+	assert.Equal(t, "Container", groups[0])
+
+	comments := make([]string, 0, 2)
+	for _, line := range f.groups[0].lines {
+		if line.isComment {
+			comments = append(comments, line.value)
+		}
+	}
+
+	assert.Len(t, comments, 2)
+	assert.Equal(t, "# comment", comments[0])
+	assert.Equal(t, "; another comment", comments[1])
+}
+
 func FuzzParser(f *testing.F) {
 	for _, sample := range samples {
 		f.Add([]byte(sample))


### PR DESCRIPTION
Currently the unit file parser supports `#` and `:` characters to define comments. But, the documentation states that the characters used for comments are `#` and `;` [Systemd Documentation](https://www.freedesktop.org/software/systemd/man/latest/systemd.syntax.html)

This PR aims to add support to `;` for comments in unit files as per systemd documentation without breaking changes by leaving `:` as a supported character for commenting.

The character `:` should eventually not be supported anymore and does not cause problems at the moment because systemd ignores lines with wrong syntax.

An example of a systemd service:
```ini
[Unit]
Description=Hello World Service
After=systend-user-sessions.service
# A comment
; another comment
: a bad comment

[Service]
Type=simple
ExecStart=/home/ahmed/hello-world.sh
```
By checking logs with `journalctl -u hello-world -e` I get this in the logs as a warning but the service runs correctly:
```txt
systemd[1]: /etc/systemd/system/hello-world.service:6: Missing '=', ignoring line.
```

#### Does this PR introduce a user-facing change?
No, because I kept `:` as a valid character for comment to prevent breaking parsing for people already using it